### PR TITLE
Correctly clear RAPTOR and ULTRARAPTOR earliest arrival times

### DIFF
--- a/Algorithms/RAPTOR/RAPTOR.h
+++ b/Algorithms/RAPTOR/RAPTOR.h
@@ -101,7 +101,7 @@ private:
             std::vector<int>(earliestArrival.size(), never).swap(earliestArrival);
         } else {
             rounds.clear();
-            Vector::fill(earliestArrival);
+            Vector::fill(earliestArrival, never);
         }
     }
 

--- a/Algorithms/RAPTOR/ULTRARAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRARAPTOR.h
@@ -110,7 +110,7 @@ private:
             std::vector<int>(earliestArrival.size(), never).swap(earliestArrival);
         } else {
             rounds.clear();
-            Vector::fill(earliestArrival);
+            Vector::fill(earliestArrival, never);
         }
     }
 


### PR DESCRIPTION
The non-reset clear was setting earliest arrivals to 0.