### PR TITLE
Steil Branch, Graph Serialize, GraphML Export, Timestamp Overflow && Optimizations

### DIFF
--- a/Algorithms/CSA/CSA.h
+++ b/Algorithms/CSA/CSA.h
@@ -140,6 +140,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+
             const Connection& connection = data.connections[i];
             if (targetStop != noStop && connection.departureTime > arrivalTime[targetStop]) break;
             if (connectionIsReachable(connection, i)) {

--- a/Algorithms/CSA/DijkstraCSA.h
+++ b/Algorithms/CSA/DijkstraCSA.h
@@ -174,6 +174,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+            
             const Connection& connection = data.connections[i];
             runDijkstra(connection.departureTime);
             if (targetStop != noStop && connection.departureTime > arrivalTime[targetStop]) break;
@@ -298,3 +305,4 @@ private:
 
 };
 }
+

--- a/Algorithms/CSA/HLCSA.h
+++ b/Algorithms/CSA/HLCSA.h
@@ -149,6 +149,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+            
             const Connection& connection = data.connections[i];
             if (targetVertex != noVertex && connection.departureTime > arrivalTime[targetVertex]) break;
             if (connectionIsReachable(connection, i)) {
@@ -251,3 +258,4 @@ private:
 
 };
 }
+

--- a/Algorithms/CSA/OneToAllDijkstraCSA.h
+++ b/Algorithms/CSA/OneToAllDijkstraCSA.h
@@ -167,6 +167,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+            
             const Connection& connection = data.connections[i];
             runDijkstra(connection.departureTime);
             if (connectionIsReachable(connection, i)) {
@@ -269,3 +276,4 @@ private:
 
 };
 }
+

--- a/Algorithms/CSA/ULTRACSA.h
+++ b/Algorithms/CSA/ULTRACSA.h
@@ -159,6 +159,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+            
             const Connection& connection = data.connections[i];
             if (targetStop != noStop && connection.departureTime > arrivalTime[targetStop]) break;
             if (connectionIsReachable(connection, i)) {
@@ -258,3 +265,4 @@ private:
 
 };
 }
+

--- a/Algorithms/CSA/UPCSA.h
+++ b/Algorithms/CSA/UPCSA.h
@@ -256,6 +256,13 @@ private:
 
     inline void scanConnections(const ConnectionId begin, const ConnectionId end) noexcept {
         for (ConnectionId i = begin; i < end; i++) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < end) {
+                __builtin_prefetch(&data.connections[i + 4]);
+                data.transferGraph.prefetchBeginOut(data.connections[i + 4].arrivalStopId);
+            }
+            #endif
+            
             const Connection& connection = data.connections[i];
             if (connectionIsReachable(connection, i)) {
                 profiler.countMetric(METRIC_CONNECTIONS);
@@ -345,3 +352,4 @@ private:
 
 };
 }
+

--- a/Algorithms/DepthFirstSearch.h
+++ b/Algorithms/DepthFirstSearch.h
@@ -117,7 +117,7 @@ private:
 
 template<typename GRAPH, typename OPERATION>
 struct SimpleOperation {
-    SimpleOperation(const GRAPH& graph, const OPERATION& operation) : graph(graph), operation(operation) {}
+    SimpleOperation(const GRAPH& graph, const OPERATION& operation) : operation(operation), graph(graph) {}
     inline void operator()(const Edge edge, const Vertex) {operation(graph.get(ToVertex, edge));}
     OPERATION operation;
     const GRAPH& graph;

--- a/Algorithms/RAPTOR/Bounded/BackwardPruningRAPTOR.h
+++ b/Algorithms/RAPTOR/Bounded/BackwardPruningRAPTOR.h
@@ -135,14 +135,14 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < previousRoundLabel(stop).arrivalTimeByTransfer) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < previousRoundLabel(stop).arrivalTimeByTransfer) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -267,3 +267,4 @@ private:
 };
 
 }
+

--- a/Algorithms/RAPTOR/Bounded/BoundedMcRAPTOR.h
+++ b/Algorithms/RAPTOR/Bounded/BoundedMcRAPTOR.h
@@ -261,13 +261,13 @@ private:
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -442,3 +442,4 @@ private:
 };
 
 }
+

--- a/Algorithms/RAPTOR/Bounded/ForwardPruningRAPTOR.h
+++ b/Algorithms/RAPTOR/Bounded/ForwardPruningRAPTOR.h
@@ -118,14 +118,14 @@ private:
             const int arrivalTime = previousRound()[stop].arrivalTimeByTransfer;
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -243,3 +243,4 @@ private:
 };
 
 }
+

--- a/Algorithms/RAPTOR/DijkstraRAPTOR.h
+++ b/Algorithms/RAPTOR/DijkstraRAPTOR.h
@@ -313,14 +313,14 @@ private:
     inline void collectRoutesServingUpdatedStops(const ARRIVAL_TIME& arrivalTime) noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime(stop)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime(stop)) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/HLRAPTOR.h
+++ b/Algorithms/RAPTOR/HLRAPTOR.h
@@ -246,21 +246,21 @@ private:
             stopsUpdatedByTransfer.insert(StopId(source));
         }
     }
-
+    
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             const int arrivalTime = previousRound()[stop].arrivalTime;
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/MCR.h
+++ b/Algorithms/RAPTOR/MCR.h
@@ -270,17 +270,17 @@ private:
         }
         startNewRound();
     }
-
+    
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/McRAPTOR.h
+++ b/Algorithms/RAPTOR/McRAPTOR.h
@@ -258,13 +258,13 @@ private:
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/MultimodalMCR.h
+++ b/Algorithms/RAPTOR/MultimodalMCR.h
@@ -383,13 +383,13 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.raptorData.routesContainingStop(stop)) {
-                AssertMsg(data.raptorData.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.raptorData.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.raptorData.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.raptorData.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/MultimodalULTRAMcRAPTOR.h
+++ b/Algorithms/RAPTOR/MultimodalULTRAMcRAPTOR.h
@@ -334,13 +334,13 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.raptorData.routesContainingStop(stop)) {
-                AssertMsg(data.raptorData.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.raptorData.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.raptorData.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.raptorData.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/OneToAllDijkstraRAPTOR.h
+++ b/Algorithms/RAPTOR/OneToAllDijkstraRAPTOR.h
@@ -204,14 +204,14 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < previousRound()[stop].arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < previousRound()[stop].arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/RAPTOR.h
+++ b/Algorithms/RAPTOR/RAPTOR.h
@@ -228,19 +228,30 @@ private:
     }
 
     inline void collectRoutesServingUpdatedStops() noexcept {
-        for (const StopId stop : stopsUpdatedByTransfer) {
+        auto& valuesToLoopOver = stopsUpdatedByTransfer.getValues();
+        for (size_t i = 0; i < valuesToLoopOver.size(); ++i) {
+
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < valuesToLoopOver.size()) {
+                __builtin_prefetch(&(previousRound()[valuesToLoopOver[i + 4]]));
+                __builtin_prefetch(&(data.routeSegments[data.firstRouteSegmentOfStop[valuesToLoopOver[i + 4]]]));
+            }
+            #endif
+
+            const StopId stop = valuesToLoopOver[i];
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
+            
             const int arrivalTime = previousRound()[stop].arrivalTime;
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -248,7 +259,20 @@ private:
 
     inline void scanRoutes() noexcept {
         stopsUpdatedByRoute.clear();
-        for (const RouteId route : routesServingUpdatedStops.getKeys()) {
+
+        auto& valuesToLoopOver = routesServingUpdatedStops.getKeys();
+
+        for (size_t i = 0; i < valuesToLoopOver.size(); ++i) {
+
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < valuesToLoopOver.size()) {
+                __builtin_prefetch(data.stopArrayOfRoute(valuesToLoopOver[i + 4]));
+                __builtin_prefetch(data.firstTripOfRoute(valuesToLoopOver[i + 4]));
+                __builtin_prefetch(data.lastTripOfRoute(valuesToLoopOver[i + 4]));
+            }
+            #endif
+
+            const RouteId route = valuesToLoopOver[i];
             profiler.countMetric(METRIC_ROUTES);
             StopIndex stopIndex = routesServingUpdatedStops[route];
             const size_t tripSize = data.numberOfStopsInRoute(route);
@@ -284,7 +308,19 @@ private:
     inline void relaxTransfers() noexcept {
         stopsUpdatedByTransfer.clear();
         routesServingUpdatedStops.clear();
-        for (const StopId stop : stopsUpdatedByRoute) {
+
+        auto& valuesToLoopOver = stopsUpdatedByRoute.getValues();
+
+        for (size_t i = 0; i < valuesToLoopOver.size(); ++i) {
+
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < valuesToLoopOver.size()) {
+                __builtin_prefetch(SeparateRouteAndTransferEntries ? &previousRound()[valuesToLoopOver[i + 4]].arrivalTime : &currentRound()[valuesToLoopOver[i + 4]].arrivalTime);
+                data.transferGraph.prefetchBeginOut(valuesToLoopOver[i + 4]);
+            }
+            #endif
+
+            const StopId stop = valuesToLoopOver[i];
             const int earliestArrivalTime = SeparateRouteAndTransferEntries ? previousRound()[stop].arrivalTime : currentRound()[stop].arrivalTime;
             for (const Edge edge : data.transferGraph.edgesFrom(stop)) {
                 if constexpr (INITIAL_TRANSFERS && PreventDirectWalking) {

--- a/Algorithms/RAPTOR/ULTRA/McShortcutSearch.h
+++ b/Algorithms/RAPTOR/ULTRA/McShortcutSearch.h
@@ -443,7 +443,7 @@ public:
         RouteSegment route;
         int departureTime;
         inline bool operator<(const DepartureLabel& other) const noexcept {
-            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.routeId < other.route.routeId));
+            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.getRouteId() < other.route.getRouteId()));
         }
     };
 
@@ -581,7 +581,7 @@ private:
         sort(departureLabels);
         std::vector<ConsolidatedDepartureLabel> result(1);
         for (const DepartureLabel& label : departureLabels) {
-            if (label.route.routeId == noRouteId) {
+            if (label.route.getRouteId() == noRouteId) {
                 if (label.departureTime == result.back().departureTime) continue;
                 result.back().departureTime = label.departureTime;
                 result.emplace_back(label.departureTime);
@@ -623,13 +623,13 @@ private:
 
     inline void collectRoutes1(const std::vector<RouteSegment>& routes) noexcept {
         for (const RouteSegment& route : routes) {
-            AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-            AssertMsg(route.stopIndex + 1 < data.numberOfStopsInRoute(route.routeId), "RouteSegment " << route << " is not a departure event!");
-            AssertMsg(data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
-            if (routesServingUpdatedStops.contains(route.routeId)) {
-                routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+            AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+            AssertMsg(route.getStopIndex() + 1 < data.numberOfStopsInRoute(route.getRouteId()), "RouteSegment " << route << " is not a departure event!");
+            AssertMsg(data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
+            if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
             } else {
-                routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
             }
         }
         AssertMsg(routesServingUpdatedStops.isSortedByKeys(), "Collected route segments are not sorted!");
@@ -638,13 +638,13 @@ private:
     inline void collectRoutes2() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -1049,3 +1049,4 @@ private:
 };
 
 }
+

--- a/Algorithms/RAPTOR/ULTRA/MultimodalMcShortcutSearch.h
+++ b/Algorithms/RAPTOR/ULTRA/MultimodalMcShortcutSearch.h
@@ -487,7 +487,7 @@ public:
         RouteSegment route;
         int departureTime;
         inline bool operator<(const DepartureLabel& other) const noexcept {
-            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.routeId < other.route.routeId));
+            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.getRouteId() < other.route.getRouteId()));
         }
     };
 
@@ -625,7 +625,7 @@ private:
         sort(departureLabels);
         std::vector<ConsolidatedDepartureLabel> result(1);
         for (const DepartureLabel& label : departureLabels) {
-            if (label.route.routeId == noRouteId) {
+            if (label.route.getRouteId() == noRouteId) {
                 if (label.departureTime == result.back().departureTime) continue;
                 result.back().departureTime = label.departureTime;
                 result.emplace_back(label.departureTime);
@@ -667,13 +667,13 @@ private:
 
     inline void collectRoutes1(const std::vector<RouteSegment>& routes) noexcept {
         for (const RouteSegment& route : routes) {
-            AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-            AssertMsg(route.stopIndex + 1 < data.numberOfStopsInRoute(route.routeId), "RouteSegment " << route << " is not a departure event!");
-            AssertMsg(data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
-            if (routesServingUpdatedStops.contains(route.routeId)) {
-                routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+            AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+            AssertMsg(route.getStopIndex() + 1 < data.numberOfStopsInRoute(route.getRouteId()), "RouteSegment " << route << " is not a departure event!");
+            AssertMsg(data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
+            if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
             } else {
-                routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
             }
         }
         AssertMsg(routesServingUpdatedStops.isSortedByKeys(), "Collected route segments are not sorted!");
@@ -682,13 +682,13 @@ private:
     inline void collectRoutes2() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -1170,3 +1170,4 @@ private:
 };
 
 }
+

--- a/Algorithms/RAPTOR/ULTRABounded/BackwardPruningULTRARAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRABounded/BackwardPruningULTRARAPTOR.h
@@ -121,18 +121,18 @@ private:
         arrivalByRoute(sourceStop, sourceDepartureTime);
         startNewRound();
     }
-
+    
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < previousRoundLabel(stop).arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < previousRoundLabel(stop).arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRABounded/ForwardPruningULTRARAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRABounded/ForwardPruningULTRARAPTOR.h
@@ -112,14 +112,14 @@ private:
             const int arrivalTime = previousRound()[stop];
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRABounded/MultimodalUBMHydRA.h
+++ b/Algorithms/RAPTOR/ULTRABounded/MultimodalUBMHydRA.h
@@ -441,13 +441,13 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : raptorData.routesContainingStop(stop)) {
-                AssertMsg(raptorData.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(raptorData.stopIds[raptorData.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == raptorData.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(raptorData.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(raptorData.stopIds[raptorData.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == raptorData.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRABounded/MultimodalUBMRAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRABounded/MultimodalUBMRAPTOR.h
@@ -389,13 +389,13 @@ private:
     inline void collectRoutesServingUpdatedStops() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RouteSegment& route : data.raptorData.routesContainingStop(stop)) {
-                AssertMsg(data.raptorData.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.raptorData.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.raptorData.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.raptorData.stopIds[data.raptorData.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.raptorData.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRABounded/UBMHydRA.h
+++ b/Algorithms/RAPTOR/ULTRABounded/UBMHydRA.h
@@ -294,13 +294,13 @@ private:
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRABounded/UBMRAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRABounded/UBMRAPTOR.h
@@ -266,13 +266,13 @@ private:
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRAMcRAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRAMcRAPTOR.h
@@ -238,13 +238,13 @@ private:
         for (const StopId stop : stopsUpdatedByTransfer) {
             AssertMsg(data.isStop(stop), "Stop " << stop << " is out of range!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/ULTRARAPTOR.h
+++ b/Algorithms/RAPTOR/ULTRARAPTOR.h
@@ -280,14 +280,14 @@ private:
             const int arrivalTime = previousRound()[stop].arrivalTime;
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/RAPTOR/UPRAPTOR.h
+++ b/Algorithms/RAPTOR/UPRAPTOR.h
@@ -277,14 +277,14 @@ private:
             const int arrivalTime = previousRound()[stop].arrivalTime;
             AssertMsg(arrivalTime < never, "Updated stop has arrival time = never!");
             for (const RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }

--- a/Algorithms/TripBased/BoundedMcQuery/BackwardPruningQuery.h
+++ b/Algorithms/TripBased/BoundedMcQuery/BackwardPruningQuery.h
@@ -150,7 +150,7 @@ private:
             for (const RAPTOR::RouteSegment& segment : data.routesContainingStop(StopId(stop))) {
                 const TripId trip = data.getEarliestTrip(segment, stopDepartureTime);
                 if (trip != noTripId) {
-                    enqueue(trip, StopIndex(segment.stopIndex + 1));
+                    enqueue(trip, StopIndex(segment.getStopIndex() + 1));
                 }
             }
         }

--- a/Algorithms/TripBased/BoundedMcQuery/BoundedMcQuery.h
+++ b/Algorithms/TripBased/BoundedMcQuery/BoundedMcQuery.h
@@ -207,7 +207,7 @@ private:
             addTargetLabel(label);
         }
     }
-
+    
     inline void evaluateInitialTransfers() noexcept {
         for (const Vertex stop : bucketQuery.getForwardPOIs()) {
             const int timeFromSource = bucketQuery.getForwardDistance(stop);
@@ -217,7 +217,7 @@ private:
             for (const RAPTOR::RouteSegment& segment : data.routesContainingStop(StopId(stop))) {
                 const TripId trip = data.getEarliestTrip(segment, stopDepartureTime);
                 if (trip != noTripId) {
-                    enqueue(trip, StopIndex(segment.stopIndex + 1), timeFromSource);
+                    enqueue(trip, StopIndex(segment.getStopIndex() + 1), timeFromSource);
                 }
             }
         }

--- a/Algorithms/TripBased/BoundedMcQuery/ForwardPruningQuery.h
+++ b/Algorithms/TripBased/BoundedMcQuery/ForwardPruningQuery.h
@@ -127,7 +127,7 @@ private:
         std::vector<bool> reachedRoutes(data.numberOfRoutes(), false);
         for (const Vertex stop : bucketQuery.getForwardPOIs()) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(StopId(stop))) {
-                reachedRoutes[route.routeId] = true;
+                reachedRoutes[route.getRouteId()] = true;
             }
         }
         for (const RouteId route : data.routes()) {

--- a/Algorithms/TripBased/Preprocessing/McShortcutSearch.h
+++ b/Algorithms/TripBased/Preprocessing/McShortcutSearch.h
@@ -431,7 +431,7 @@ public:
         RAPTOR::RouteSegment route;
         int departureTime;
         inline bool operator<(const DepartureLabel& other) const noexcept {
-            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.routeId < other.route.routeId));
+            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.getRouteId() < other.route.getRouteId()));
         }
     };
 
@@ -565,7 +565,7 @@ private:
         sort(departureLabels);
         std::vector<ConsolidatedDepartureLabel> result(1);
         for (const DepartureLabel& label : departureLabels) {
-            if (label.route.routeId == noRouteId) {
+            if (label.route.getRouteId() == noRouteId) {
                 if (label.departureTime == result.back().departureTime) continue;
                 result.back().departureTime = label.departureTime;
                 result.emplace_back(label.departureTime);
@@ -606,13 +606,13 @@ private:
 
     inline void collectRoutes1(const std::vector<RAPTOR::RouteSegment>& routes) noexcept {
         for (const RAPTOR::RouteSegment& route : routes) {
-            AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-            AssertMsg(route.stopIndex + 1 < data.numberOfStopsInRoute(route.routeId), "RouteSegment " << route << " is not a departure event!");
-            AssertMsg(data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
-            if (routesServingUpdatedStops.contains(route.routeId)) {
-                routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+            AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+            AssertMsg(route.getStopIndex() + 1 < data.numberOfStopsInRoute(route.getRouteId()), "RouteSegment " << route << " is not a departure event!");
+            AssertMsg(data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
+            if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
             } else {
-                routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
             }
         }
         AssertMsg(routesServingUpdatedStops.isSortedByKeys(), "Collected route segments are not sorted!");
@@ -621,13 +621,13 @@ private:
     inline void collectRoutes2() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -1032,3 +1032,4 @@ private:
 };
 
 }
+

--- a/Algorithms/TripBased/Preprocessing/MultimodalMcShortcutSearch.h
+++ b/Algorithms/TripBased/Preprocessing/MultimodalMcShortcutSearch.h
@@ -475,7 +475,7 @@ public:
         RAPTOR::RouteSegment route;
         int departureTime;
         inline bool operator<(const DepartureLabel& other) const noexcept {
-            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.routeId < other.route.routeId));
+            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.getRouteId() < other.route.getRouteId()));
         }
     };
 
@@ -609,7 +609,7 @@ private:
         sort(departureLabels);
         std::vector<ConsolidatedDepartureLabel> result(1);
         for (const DepartureLabel& label : departureLabels) {
-            if (label.route.routeId == noRouteId) {
+            if (label.route.getRouteId() == noRouteId) {
                 if (label.departureTime == result.back().departureTime) continue;
                 result.back().departureTime = label.departureTime;
                 result.emplace_back(label.departureTime);
@@ -650,13 +650,13 @@ private:
 
     inline void collectRoutes1(const std::vector<RAPTOR::RouteSegment>& routes) noexcept {
         for (const RAPTOR::RouteSegment& route : routes) {
-            AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-            AssertMsg(route.stopIndex + 1 < data.numberOfStopsInRoute(route.routeId), "RouteSegment " << route << " is not a departure event!");
-            AssertMsg(data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
-            if (routesServingUpdatedStops.contains(route.routeId)) {
-                routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+            AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+            AssertMsg(route.getStopIndex() + 1 < data.numberOfStopsInRoute(route.getRouteId()), "RouteSegment " << route << " is not a departure event!");
+            AssertMsg(data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime >= initialArrivalTime(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
+            if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
             } else {
-                routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
             }
         }
         AssertMsg(routesServingUpdatedStops.isSortedByKeys(), "Collected route segments are not sorted!");
@@ -665,13 +665,13 @@ private:
     inline void collectRoutes2() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -1153,3 +1153,4 @@ private:
 };
 
 }
+

--- a/Algorithms/TripBased/Preprocessing/ShortcutSearch.h
+++ b/Algorithms/TripBased/Preprocessing/ShortcutSearch.h
@@ -41,7 +41,7 @@ public:
         RAPTOR::RouteSegment route;
         int departureTime;
         inline bool operator<(const DepartureLabel& other) const noexcept {
-            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.routeId < other.route.routeId));
+            return (departureTime > other.departureTime) || ((departureTime == other.departureTime) && (route.getRouteId() < other.route.getRouteId()));
         }
     };
 
@@ -167,7 +167,7 @@ private:
         sort(departureLabels);
         std::vector<ConsolidatedDepartureLabel> result(1);
         for (const DepartureLabel& label : departureLabels) {
-            if (label.route.routeId == noRouteId) {
+            if (label.route.getRouteId() == noRouteId) {
                 if (label.departureTime == result.back().departureTime) continue;
                 result.back().departureTime = label.departureTime;
                 result.emplace_back(label.departureTime);
@@ -212,13 +212,13 @@ private:
 
     inline void collectRoutes1(const std::vector<RAPTOR::RouteSegment>& routes) noexcept {
         for (const RAPTOR::RouteSegment& route : routes) {
-            AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-            AssertMsg(route.stopIndex + 1 < data.numberOfStopsInRoute(route.routeId), "RouteSegment " << route << " is not a departure event!");
-            AssertMsg(data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime >= arrivalTime<0>(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
-            if (routesServingUpdatedStops.contains(route.routeId)) {
-                routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+            AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+            AssertMsg(route.getStopIndex() + 1 < data.numberOfStopsInRoute(route.getRouteId()), "RouteSegment " << route << " is not a departure event!");
+            AssertMsg(data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime >= arrivalTime<0>(data.stopOfRouteSegment(route)), "RouteSegment " << route << " is not reachable!");
+            if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
             } else {
-                routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
             }
         }
         AssertMsg(routesServingUpdatedStops.isSortedByKeys(), "Collected route segments are not sorted!");
@@ -227,14 +227,14 @@ private:
     inline void collectRoutes2() noexcept {
         for (const StopId stop : stopsUpdatedByTransfer) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(stop)) {
-                AssertMsg(data.isRoute(route.routeId), "Route " << route.routeId << " is out of range!");
-                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.routeId] + route.stopIndex] == stop, "RAPTOR data contains invalid route segments!");
-                if (route.stopIndex + 1 == data.numberOfStopsInRoute(route.routeId)) continue;
-                if (data.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < oneTripArrivalLabels[stop].arrivalTime) continue;
-                if (routesServingUpdatedStops.contains(route.routeId)) {
-                    routesServingUpdatedStops[route.routeId] = std::min(routesServingUpdatedStops[route.routeId], route.stopIndex);
+                AssertMsg(data.isRoute(route.getRouteId()), "Route " << route.getRouteId() << " is out of range!");
+                AssertMsg(data.stopIds[data.firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()] == stop, "RAPTOR data contains invalid route segments!");
+                if (route.getStopIndex() + 1 == data.numberOfStopsInRoute(route.getRouteId())) continue;
+                if (data.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < oneTripArrivalLabels[stop].arrivalTime) continue;
+                if (routesServingUpdatedStops.contains(route.getRouteId())) {
+                    routesServingUpdatedStops[route.getRouteId()] = std::min(routesServingUpdatedStops[route.getRouteId()], route.getStopIndex());
                 } else {
-                    routesServingUpdatedStops.insert(route.routeId, route.stopIndex);
+                    routesServingUpdatedStops.insert(route.getRouteId(), route.getStopIndex());
                 }
             }
         }
@@ -631,3 +631,4 @@ private:
 };
 
 }
+

--- a/Algorithms/TripBased/Preprocessing/StopEventGraphBuilder.h
+++ b/Algorithms/TripBased/Preprocessing/StopEventGraphBuilder.h
@@ -111,6 +111,12 @@ public:
 
     inline void reduceTransfers(const TripId trip) noexcept {
         timestamp++;
+
+        if (timestamp == 0) {
+            labels.clear();
+            labels.resize(data.numberOfStops());
+        }
+
         const StopId* stops = data.stopArrayOfTrip(trip);
         for (StopIndex i = StopIndex(data.numberOfStopsInTrip(trip) - 1); i > 0; i--) {
             const int arrivalTime = data.getStopEvent(trip, i).arrivalTime;

--- a/Algorithms/TripBased/Preprocessing/StopEventGraphBuilder.h
+++ b/Algorithms/TripBased/Preprocessing/StopEventGraphBuilder.h
@@ -194,14 +194,14 @@ private:
         for (StopIndex i(data.numberOfStopsInRoute(fromRoute) - 1); i > 0; i--) {
             const StopId fromStop = stops[i];
             for (const RAPTOR::RouteSegment& toSegment : data.raptorData.routesContainingStop(fromStop)) {
-                if (toSegment.routeId == fromRoute && toSegment.stopIndex == i) continue;
-                routeTransfers.emplace_back(toSegment.routeId, i, toSegment.stopIndex, 0);
+                if (toSegment.getRouteId() == fromRoute && toSegment.getStopIndex() == i) continue;
+                routeTransfers.emplace_back(toSegment.getRouteId(), i, toSegment.getStopIndex(), 0);
             }
             for (const Edge edge : data.raptorData.transferGraph.edgesFrom(fromStop)) {
                 const StopId toStop = StopId(data.raptorData.transferGraph.get(ToVertex, edge));
                 const int transferTime = data.raptorData.transferGraph.get(TravelTime, edge);
                 for (const RAPTOR::RouteSegment& toRouteSegment : data.raptorData.routesContainingStop(toStop)) {
-                    routeTransfers.emplace_back(toRouteSegment.routeId, i, toRouteSegment.stopIndex, transferTime);
+                    routeTransfers.emplace_back(toRouteSegment.getRouteId(), i, toRouteSegment.getStopIndex(), transferTime);
                 }
             }
         }
@@ -214,10 +214,10 @@ private:
         for (const RAPTOR::RouteSegment& toSegment : data.raptorData.routesContainingStop(toStop)) {
             const TripId toTrip = data.getEarliestTrip(toSegment, toArrivalTime);
             if (toTrip == noTripId) continue;
-            if ((toSegment.routeId == fromRoute) && (toTrip >= fromTrip) && (toSegment.stopIndex >= fromIndex)) continue;
-            if (isUTurn(fromTrip, fromIndex, toTrip, toSegment.stopIndex)) continue;
+            if ((toSegment.getRouteId() == fromRoute) && (toTrip >= fromTrip) && (toSegment.getStopIndex() >= fromIndex)) continue;
+            if (isUTurn(fromTrip, fromIndex, toTrip, toSegment.getStopIndex())) continue;
             const Vertex fromVertex = Vertex(data.getStopEventId(fromTrip, fromIndex));
-            const Vertex toVertex = Vertex(data.getStopEventId(toTrip, toSegment.stopIndex));
+            const Vertex toVertex = Vertex(data.getStopEventId(toTrip, toSegment.getStopIndex()));
             generatedTransfers.addEdge(fromVertex, toVertex);
         }
     }
@@ -344,3 +344,4 @@ inline void ComputeStopEventGraphRouteBased(Data& data, const int numberOfThread
 }
 
 }
+

--- a/Algorithms/TripBased/Query/McQuery.h
+++ b/Algorithms/TripBased/Query/McQuery.h
@@ -172,7 +172,7 @@ private:
         std::vector<bool> reachedRoutes(data.numberOfRoutes(), false);
         for (const Vertex stop : bucketQuery.getForwardPOIs()) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(StopId(stop))) {
-                reachedRoutes[route.routeId] = true;
+                reachedRoutes[route.getRouteId()] = true;
             }
         }
         for (const RouteId route : data.routes()) {

--- a/Algorithms/TripBased/Query/Query.h
+++ b/Algorithms/TripBased/Query/Query.h
@@ -162,7 +162,7 @@ private:
         std::vector<bool> reachedRoutes(data.numberOfRoutes(), false);
         for (const Vertex stop : bucketQuery.getForwardPOIs()) {
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(StopId(stop))) {
-                reachedRoutes[route.routeId] = true;
+                reachedRoutes[route.getRouteId()] = true;
             }
         }
         for (const RouteId route : data.routes()) {

--- a/Algorithms/TripBased/Query/TransitiveQuery.h
+++ b/Algorithms/TripBased/Query/TransitiveQuery.h
@@ -189,16 +189,26 @@ private:
         profiler.startPhase();
         reachedRoutes.clear();
         for (const RAPTOR::RouteSegment& route : data.routesContainingStop(sourceStop)) {
-            reachedRoutes.insert(route.routeId);
+            reachedRoutes.insert(route.getRouteId());
         }
         for (const Edge edge : transferGraph.edgesFrom(sourceStop)) {
             const Vertex stop = transferGraph.get(ToVertex, edge);
             for (const RAPTOR::RouteSegment& route : data.routesContainingStop(StopId(stop))) {
-                reachedRoutes.insert(route.routeId);
+                reachedRoutes.insert(route.getRouteId());
             }
         }
         reachedRoutes.sort();
-        for (const RouteId route : reachedRoutes) {
+        auto& valuesToLoopOver = reachedRoutes.getValues();
+
+        for (size_t i = 0; i < valuesToLoopOver.size(); ++i) {
+            #ifdef ENABLE_PREFETCH
+            if (i + 4 < valuesToLoopOver.size()) {
+                __builtin_prefetch(&(routeLabels[valuesToLoopOver[i + 4]]));
+                __builtin_prefetch(&(data.firstTripOfRoute[valuesToLoopOver[i + 4]]));
+            }
+            #endif
+
+            const RouteId route = valuesToLoopOver[i];
             const RouteLabel& label = routeLabels[route];
             const StopIndex endIndex = label.end();
             const TripId firstTrip = data.firstTripOfRoute[route];
@@ -225,6 +235,13 @@ private:
             targetLabels.emplace_back(targetLabels.back());
             // Evaluate final transfers in order to check if the target is reachable
             for (size_t i = roundBegin; i < roundEnd; i++) {
+                #ifdef ENABLE_PREFETCH
+                if (i + 4 < roundEnd) {
+                    __builtin_prefetch(&(queue[i + 4]));
+                    __builtin_prefetch(&(data.arrivalEvents[queue[i + 4].begin]));
+                }
+                #endif
+
                 const TripLabel& label = queue[i];
                 profiler.countMetric(METRIC_SCANNED_TRIPS);
                 for (StopEventId j = label.begin; j < label.end; j++) {
@@ -236,6 +253,13 @@ private:
             }
             // Find the range of transfers for each trip
             for (size_t i = roundBegin; i < roundEnd; i++) {
+                #ifdef ENABLE_PREFETCH
+                if (i + 4 < roundEnd) {
+                    __builtin_prefetch(&(queue[i + 4]));
+                    __builtin_prefetch(&(data.arrivalEvents[queue[i + 4].begin]));
+                }
+                #endif
+                
                 TripLabel& label = queue[i];
                 for (StopEventId j = label.begin; j < label.end; j++) {
                     if (data.arrivalEvents[j].arrivalTime >= minArrivalTime) label.end = j;
@@ -374,3 +398,4 @@ private:
 };
 
 }
+

--- a/DataStructures/Graph/Classes/DynamicGraph.h
+++ b/DataStructures/Graph/Classes/DynamicGraph.h
@@ -745,6 +745,30 @@ public:
     }
 
     // IO:
+    inline void serialize(IO::Serialization& serialize) const {
+        serialize(vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(IO::Deserialization& deserialize) {
+        clear();
+        deserialize(vertexAttributes, edgeAttributes);
+        for (const Vertex vertex : vertices())
+            edgeCount += outDegree(vertex);
+        Assert(satisfiesInvariants());
+    }
+
+    inline void serialize(const std::string& fileName) const {
+        IO::serialize(fileName, vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(const std::string& fileName) {
+        clear();
+        IO::deserialize(fileName, vertexAttributes, edgeAttributes);
+        for (const Vertex vertex : vertices())
+            edgeCount += outDegree(vertex);
+        Assert(satisfiesInvariants());
+    }
+
     inline void writeBinary(const std::string& fileName, const std::string& separator = ".") const noexcept {
         vertexAttributes.serialize(fileName, separator);
         edgeAttributes.serialize(fileName, separator);

--- a/DataStructures/Graph/Classes/EdgeList.h
+++ b/DataStructures/Graph/Classes/EdgeList.h
@@ -481,6 +481,24 @@ public:
     }
 
     // IO:
+    inline void serialize(IO::Serialization& serialize) const {
+        serialize(vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(IO::Deserialization& deserialize) {
+        clear();
+        deserialize(vertexAttributes, edgeAttributes);
+    }
+
+    inline void serialize(const std::string& fileName) const {
+        IO::serialize(fileName, vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(const std::string& fileName) {
+        clear();
+        IO::deserialize(fileName, vertexAttributes, edgeAttributes);
+    }
+
     inline void writeBinary(const std::string& fileName, const std::string& separator = ".") const noexcept {
         vertexAttributes.serialize(fileName, separator);
         edgeAttributes.serialize(fileName, separator);

--- a/DataStructures/Graph/Classes/StaticGraph.h
+++ b/DataStructures/Graph/Classes/StaticGraph.h
@@ -775,6 +775,12 @@ public:
         return true;
     }
 
+    inline void prefetchBeginOut(const Vertex vertex) const noexcept {
+        AssertMsg(isVertex(vertex), "Vertex is not valid!");
+
+        __builtin_prefetch(&beginOut[vertex]);
+    }
+
 private:
     std::vector<Edge> beginOut;
     VertexAttributes vertexAttributes;

--- a/DataStructures/Graph/Classes/StaticGraph.h
+++ b/DataStructures/Graph/Classes/StaticGraph.h
@@ -511,6 +511,26 @@ public:
     }
 
     // IO:
+    inline void serialize(IO::Serialization& serialize) const {
+        serialize(beginOut, vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(IO::Deserialization& deserialize) {
+        clear();
+        deserialize(beginOut, vertexAttributes, edgeAttributes);
+        AssertMsg(satisfiesInvariants(), "Invariants not satisfied!");
+    }
+
+    inline void serialize(const std::string& fileName) const {
+        IO::serialize(fileName, beginOut, vertexAttributes, edgeAttributes);
+    }
+
+    inline void deserialize(const std::string& fileName) {
+        clear();
+        IO::deserialize(fileName, beginOut, vertexAttributes, edgeAttributes);
+        AssertMsg(satisfiesInvariants(), "Invariants not satisfied!");
+    }
+
     inline void writeBinary(const std::string& fileName, const std::string& separator = ".") const noexcept {
         IO::serialize(fileName + separator + "beginOut", beginOut);
         vertexAttributes.serialize(fileName, separator);

--- a/DataStructures/Graph/Classes/StaticGraph.h
+++ b/DataStructures/Graph/Classes/StaticGraph.h
@@ -179,7 +179,13 @@ public:
 
     // Manipulation:
     inline void clear() noexcept {
+        beginOut.clear();
         vertexAttributes.clear();
+        edgeAttributes.clear();
+    }
+
+    inline void removeEdges() noexcept {
+        std::fill(beginOut.begin(), beginOut.end(), Edge(0));
         edgeAttributes.clear();
     }
 

--- a/DataStructures/Graph/Utils/IO.h
+++ b/DataStructures/Graph/Utils/IO.h
@@ -50,20 +50,134 @@ namespace Graph {
     inline void toDimacs(const std::string& fileBaseName, const GRAPH& graph) noexcept {
         toDimacs(fileBaseName, graph, graph.get(Weight));
     }
+    
+    template <typename GRAPH>
+    inline void toEdgeListCSV(const std::string& fileBaseName, const GRAPH& graph) noexcept
+    {
+        std::ofstream csv(fileBaseName + ".csv");
+        AssertMsg(csv, "Cannot create output stream for " << fileBaseName << ".csv");
+        AssertMsg(csv.is_open(), "Cannot open output stream for " << fileBaseName << ".csv");
+    
+        csv << "FromVertex,ToVertex";
+    
+        if constexpr (GRAPH::HasEdgeAttribute(TravelTime))
+            csv << ",TravelTime";
+        if constexpr (GRAPH::HasEdgeAttribute(Distance))
+            csv << ",Distance";
+        if constexpr (GRAPH::HasEdgeAttribute(ViaVertex))
+            csv << ",ViaVertex";
+        if constexpr (GRAPH::HasEdgeAttribute(Weight))
+            csv << ",Weight";
+        if constexpr (GRAPH::HasEdgeAttribute(Capacity))
+            csv << ",Capacity";
+        if constexpr (GRAPH::HasEdgeAttribute(BundleSize))
+            csv << ",BundleSize";
+        if constexpr (GRAPH::HasEdgeAttribute(ReverseEdge))
+            csv << ",ReverseEdge";
+        if constexpr (GRAPH::HasEdgeAttribute(EdgeFlags))
+            csv << ",EdgeFlags";
+    
+        csv << "\n";
+    
+        for (const auto [edge, from] : graph.edgesWithFromVertex()) {
+            csv << size_t(from) << "," << size_t(graph.get(ToVertex, edge));
+            if constexpr (GRAPH::HasEdgeAttribute(TravelTime))
+                csv << "," << (int)graph.get(TravelTime, edge);
+            if constexpr (GRAPH::HasEdgeAttribute(Distance))
+                csv << "," << (int)graph.get(Distance, edge);
+            if constexpr (GRAPH::HasEdgeAttribute(ViaVertex))
+                csv << "," << size_t(graph.get(ViaVertex, edge));
+            if constexpr (GRAPH::HasEdgeAttribute(Weight))
+                csv << "," << (int)graph.get(Weight, edge);
+            if constexpr (GRAPH::HasEdgeAttribute(Capacity))
+                csv << "," << (int)graph.get(Capacity, edge);
+            if constexpr (GRAPH::HasEdgeAttribute(BundleSize))
+                csv << "," << (int)graph.get(BundleSize, edge);
+            if constexpr (GRAPH::HasEdgeAttribute(ReverseEdge))
+                csv << "," << size_t(graph.get(ReverseEdge, edge));
+            if constexpr (GRAPH::HasEdgeAttribute(EdgeFlags))
+                csv << "," << join(graph.get(EdgeFlags, edge));
+            csv << "\n";
+        }
+        csv.close();
+    }
 
-    template<typename GRAPH>
-    inline void toGML(const std::string& fileBaseName, const GRAPH& graph) noexcept {
-        std::ofstream gml(fileBaseName + ".gml");
-        AssertMsg(gml, "Cannot create output stream for " << fileBaseName << ".gml");
-        AssertMsg(gml.is_open(), "Cannot open output stream for " << fileBaseName << ".gml");
+    template <typename GRAPH>
+    inline void toGML(const std::string& fileBaseName, const GRAPH& graph) noexcept
+    {
+        std::ofstream gml(fileBaseName + ".graphml");
+        AssertMsg(gml, "Cannot create output stream for " << fileBaseName << ".graphml");
+        AssertMsg(gml.is_open(), "Cannot open output stream for " << fileBaseName << ".graphml");
         gml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-        gml << "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
+        gml << "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+               "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
+               "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+               "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
+        if constexpr (GRAPH::HasVertexAttribute(Coordinates)) {
+            gml << "        <key id=\"lat_n\" for=\"node\" attr.name=\"latitude\" attr.type=\"double\"/>\n";
+            gml << "        <key id=\"lon_n\" for=\"node\" attr.name=\"longitude\" attr.type=\"double\"/>\n";
+        }
+        if constexpr (GRAPH::HasVertexAttribute(Size))
+            gml << "        <key id=\"size_n\" for=\"node\" attr.name=\"size\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasVertexAttribute(Weight))
+            gml << "        <key id=\"weight_n\" for=\"node\" attr.name=\"weight\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasVertexAttribute(ViaVertex))
+            gml << "        <key id=\"viavertex_n\" for=\"node\" attr.name=\"viavertex\" attr.type=\"int\"/>\n";
+    
+        if constexpr (GRAPH::HasEdgeAttribute(TravelTime))
+            gml << "        <key id=\"traveltime_e\" for=\"edge\" attr.name=\"traveltime\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(Distance))
+            gml << "        <key id=\"distance_e\" for=\"edge\" attr.name=\"distance\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(Size))
+            gml << "        <key id=\"size_e\" for=\"edge\" attr.name=\"edgesize\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(BundleSize))
+            gml << "        <key id=\"bundlesize_e\" for=\"edge\" attr.name=\"bundlesize\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(Weight))
+            gml << "        <key id=\"weight_e\" for=\"edge\" attr.name=\"edgeweight\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(ReverseEdge))
+            gml << "        <key id=\"reverseedge_e\" for=\"edge\" attr.name=\"reverseegde\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(Capacity))
+            gml << "        <key id=\"capacity_e\" for=\"edge\" attr.name=\"capacity\" attr.type=\"int\"/>\n";
+        if constexpr (GRAPH::HasEdgeAttribute(ViaVertex))
+            gml << "        <key id=\"viavertex_e\" for=\"edge\" attr.name=\"viavertex\" attr.type=\"int\"/>\n";
         gml << "    <graph id=\"G\" edgedefault=\"directed\">\n";
+        
         for (const Vertex vertex : graph.vertices()) {
-            gml << "        <node id=\"" << size_t(vertex) << "\"/>\n";
+            gml << "        <node id=\"" << size_t(vertex) << "\">\n";
+    
+            if constexpr (GRAPH::HasVertexAttribute(Coordinates)) {
+                gml << "            <data key=\"lat_n\">" << (float)graph.get(Coordinates, vertex).latitude << "</data>\n";
+                gml << "            <data key=\"lon_n\">" << (float)graph.get(Coordinates, vertex).longitude << "</data>\n";
+            }
+            if constexpr (GRAPH::HasVertexAttribute(Size))
+                gml << "            <data key=\"size_n\">" << (int)graph.get(Size, vertex) << "</data>\n";
+            if constexpr (GRAPH::HasVertexAttribute(Weight))
+                gml << "            <data key=\"weight_n\">" << (int)graph.get(Weight, vertex) << "</data>\n";
+            if constexpr (GRAPH::HasVertexAttribute(ViaVertex))
+                gml << "            <data key=\"viavertex_n\">" << (int)graph.get(ViaVertex, vertex) << "</data>\n";
+    
+            gml << "        </node>\n";
         }
         for (const auto [edge, from] : graph.edgesWithFromVertex()) {
-            gml << "        <edge source=\"" << size_t(from) << "\" target=\"" << size_t(graph.get(ToVertex, edge)) << "\"/>\n";
+            gml << "        <edge source=\"" << size_t(from) << "\" target=\"" << size_t(graph.get(ToVertex, edge))
+                << "\">\n";
+            if constexpr (GRAPH::HasEdgeAttribute(TravelTime))
+                gml << "            <data key=\"traveltime_e\">" << (int)graph.get(TravelTime, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(Distance))
+                gml << "            <data key=\"distance_e\">" << (int)graph.get(Distance, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(Size))
+                gml << "            <data key=\"size_e\">" << (int)graph.get(Size, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(BundleSize))
+                gml << "            <data key=\"bundlesize_e\">" << (int)graph.get(BundleSize, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(Weight))
+                gml << "            <data key=\"weight_e\">" << (int)graph.get(Weight, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(ReverseEdge))
+                gml << "            <data key=\"reverseedge_e\">" << (int)graph.get(ReverseEdge, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(Capacity))
+                gml << "            <data key=\"capacity_e\">" << (int)graph.get(Capacity, edge) << "</data>\n";
+            if constexpr (GRAPH::HasEdgeAttribute(ViaVertex))
+                gml << "            <data key=\"viavertex_e\">" << size_t(graph.get(ViaVertex, edge)) << "</data>\n";
+            gml << "        </edge>\n";
         }
         gml << "    </graph>\n";
         gml << "</graphml>" << std::endl;

--- a/DataStructures/Intermediate/Data.h
+++ b/DataStructures/Intermediate/Data.h
@@ -791,7 +791,7 @@ public:
     inline TransferGraph minTravelTimeGraph() const noexcept {
         TransferGraph result;
         result.addVertices(transferGraph.numVertices());
-        for (const Trip trip : trips) {
+        for (const Trip& trip : trips) {
             for (size_t i = 1; i < trip.stopEvents.size(); i++) {
                 if (trip.stopEvents[i - 1].stopId == trip.stopEvents[i].stopId) continue;
                 const size_t numEdges = result.numEdges();

--- a/DataStructures/RAPTOR/Data.h
+++ b/DataStructures/RAPTOR/Data.h
@@ -124,7 +124,7 @@ public:
         AssertMsg(isStop(stop), "The id " << stop << " does not represent a stop!");
         int result = 0;
         for (const RouteSegment& route : routesContainingStop(stop)) {
-            result += numberOfTripsInRoute(route.routeId);
+            result += numberOfTripsInRoute(route.getRouteId());
         }
         return result;
     }
@@ -186,8 +186,8 @@ public:
     }
 
     inline StopId stopOfRouteSegment(const RouteSegment& route) const noexcept {
-        AssertMsg(isRoute(route.routeId), "The id " << route.routeId << " does not represent a route!");
-        return stopIds[firstStopIdOfRoute[route.routeId] + route.stopIndex];
+        AssertMsg(isRoute(route.getRouteId()), "The id " << route.getRouteId() << " does not represent a route!");
+        return stopIds[firstStopIdOfRoute[route.getRouteId()] + route.getStopIndex()];
     }
 
     inline const StopEvent* firstTripOfRoute(const RouteId route) const noexcept {
@@ -231,7 +231,7 @@ public:
     }
 
     inline TripIterator getTripIterator(const RouteSegment& route) const noexcept {
-        return getTripIterator(route.routeId, route.stopIndex);
+        return getTripIterator(route.getRouteId(), route.getStopIndex());
     }
 
     inline std::vector<const StopEvent*> getLastTripByStopIndex() const noexcept {
@@ -330,12 +330,12 @@ public:
     }
 
     inline double maxRouteDistance(const RouteSegment& route) const noexcept {
-        AssertMsg(isRoute(route.routeId), "The id " << route << " does not represent a route!");
+        AssertMsg(isRoute(route.getRouteId()), "The id " << route << " does not represent a route!");
         double maxDist = 0;
-        const StopId* stops = stopArrayOfRoute(route.routeId);
-        const size_t tripSize = numberOfStopsInRoute(route.routeId);
-        for (size_t stopIndex = route.stopIndex + 1; stopIndex < tripSize; stopIndex++) {
-            const double dist = geoDistanceInCM(stopData[stops[route.stopIndex]].coordinates, stopData[stops[stopIndex]].coordinates) / 100000.0;
+        const StopId* stops = stopArrayOfRoute(route.getRouteId());
+        const size_t tripSize = numberOfStopsInRoute(route.getRouteId());
+        for (size_t stopIndex = route.getStopIndex() + 1; stopIndex < tripSize; stopIndex++) {
+            const double dist = geoDistanceInCM(stopData[stops[route.getStopIndex()]].coordinates, stopData[stops[stopIndex]].coordinates) / 100000.0;
             if (maxDist >= dist) continue;
             maxDist = dist;
         }
@@ -343,13 +343,13 @@ public:
     }
 
     inline double maxRouteSpeed(const RouteSegment& route) const noexcept {
-        AssertMsg(isRoute(route.routeId), "The id " << route << " does not represent a route!");
+        AssertMsg(isRoute(route.getRouteId()), "The id " << route << " does not represent a route!");
         double maxSpeed = 0;
-        const StopId* stops = stopArrayOfRoute(route.routeId);
-        const size_t tripSize = numberOfStopsInRoute(route.routeId);
-        for (const StopEvent* trip = firstTripOfRoute(route.routeId); trip <= lastTripOfRoute(route.routeId); trip += tripSize) {
-            for (size_t stopIndex = route.stopIndex + 1; stopIndex < tripSize; stopIndex++) {
-                const double speed = geoDistanceInCM(stopData[stops[route.stopIndex]].coordinates, stopData[stops[stopIndex]].coordinates) / (100000.0 * (trip[stopIndex].arrivalTime - trip[route.stopIndex].departureTime));
+        const StopId* stops = stopArrayOfRoute(route.getRouteId());
+        const size_t tripSize = numberOfStopsInRoute(route.getRouteId());
+        for (const StopEvent* trip = firstTripOfRoute(route.getRouteId()); trip <= lastTripOfRoute(route.getRouteId()); trip += tripSize) {
+            for (size_t stopIndex = route.getStopIndex() + 1; stopIndex < tripSize; stopIndex++) {
+                const double speed = geoDistanceInCM(stopData[stops[route.getStopIndex()]].coordinates, stopData[stops[stopIndex]].coordinates) / (100000.0 * (trip[stopIndex].arrivalTime - trip[route.getStopIndex()].departureTime));
                 if (maxSpeed >= speed) continue;
                 maxSpeed = speed;
             }
@@ -358,14 +358,14 @@ public:
     }
 
     inline double maxRouteSpeedTimesDistance(const RouteSegment& route) const noexcept {
-        AssertMsg(isRoute(route.routeId), "The id " << route << " does not represent a route!");
+        AssertMsg(isRoute(route.getRouteId()), "The id " << route << " does not represent a route!");
         double maxSpeedTimesDistance = 0;
-        const StopId* stops = stopArrayOfRoute(route.routeId);
-        const size_t tripSize = numberOfStopsInRoute(route.routeId);
-        for (const StopEvent* trip = firstTripOfRoute(route.routeId); trip <= lastTripOfRoute(route.routeId); trip += tripSize) {
-            for (size_t stopIndex = route.stopIndex + 1; stopIndex < tripSize; stopIndex++) {
-                const double dist = geoDistanceInCM(stopData[stops[route.stopIndex]].coordinates, stopData[stops[stopIndex]].coordinates) / 100000.0;
-                const double speedTimesDist = dist * dist / (trip[stopIndex].arrivalTime - trip[route.stopIndex].departureTime);
+        const StopId* stops = stopArrayOfRoute(route.getRouteId());
+        const size_t tripSize = numberOfStopsInRoute(route.getRouteId());
+        for (const StopEvent* trip = firstTripOfRoute(route.getRouteId()); trip <= lastTripOfRoute(route.getRouteId()); trip += tripSize) {
+            for (size_t stopIndex = route.getStopIndex() + 1; stopIndex < tripSize; stopIndex++) {
+                const double dist = geoDistanceInCM(stopData[stops[route.getStopIndex()]].coordinates, stopData[stops[stopIndex]].coordinates) / 100000.0;
+                const double speedTimesDist = dist * dist / (trip[stopIndex].arrivalTime - trip[route.getStopIndex()].departureTime);
                 if (maxSpeedTimesDistance >= speedTimesDist) continue;
                 maxSpeedTimesDistance = speedTimesDist;
             }
@@ -468,7 +468,7 @@ public:
         result.firstStopIdOfRoute = firstStopIdOfRoute;
         result.firstStopEventOfRoute = firstStopEventOfRoute;
         for (const RouteSegment routeSegment : routeSegments) {
-            result.routeSegments.emplace_back(routeSegment.routeId, StopIndex(numberOfStopsInRoute(routeSegment.routeId) - routeSegment.stopIndex - 1));
+            result.routeSegments.emplace_back(routeSegment.getRouteId(), StopIndex(numberOfStopsInRoute(routeSegment.getRouteId()) - routeSegment.getStopIndex() - 1));
         }
         for (const RouteId route : routes()) {
             for (size_t i = 0; i < numberOfStopsInRoute(route); i++) {

--- a/DataStructures/RAPTOR/Entities/RouteSegment.h
+++ b/DataStructures/RAPTOR/Entities/RouteSegment.h
@@ -9,6 +9,48 @@
 
 namespace RAPTOR {
 
+#ifdef USE_SMALLER_ROUTE_SEG
+class RouteSegment {
+
+public:
+    RouteSegment(const RouteId routeId = noRouteId, const StopIndex stopIndex = noStopIndex) :
+        value((routeId << 8) | stopIndex) {
+            Ensure(routeId == noRouteId || routeId < (1<<24), "Route " << routeId << " out of bounds");
+            Ensure(stopIndex == noStopIndex || stopIndex < (1<<8), "StopIndex " << stopIndex << " out of bounds");
+    }
+    RouteSegment(IO::Deserialization& deserialize) {
+        this->deserialize(deserialize);
+    }
+
+    inline RouteId getRouteId() const noexcept {
+        return static_cast<RouteId>(value >> 8);
+    }
+
+    inline StopIndex getStopIndex() const noexcept {
+        return static_cast<StopIndex>(value & ((1<<8)-1));
+    }
+
+    friend std::ostream& operator<<(std::ostream& out, const RouteSegment& r) {
+        return out << "[COMPACT] RouteSegment{" << r.getRouteId() << ", " << r.getStopIndex() << "}";
+    }
+
+    inline void serialize(IO::Serialization& serialize) const noexcept {
+        serialize(value);
+    }
+
+    inline void deserialize(IO::Deserialization& deserialize) noexcept {
+        deserialize(value);
+    }
+
+    inline bool operator<(const RouteSegment& other) const noexcept {
+        return value < other.value;
+    }
+
+public:
+    uint32_t value;
+
+};
+#else
 class RouteSegment {
 
 public:
@@ -18,6 +60,14 @@ public:
     }
     RouteSegment(IO::Deserialization& deserialize) {
         this->deserialize(deserialize);
+    }
+
+    inline RouteId getRouteId() const noexcept {
+        return routeId;
+    }
+
+    inline StopIndex getStopIndex() const noexcept {
+        return stopIndex;
     }
 
     friend std::ostream& operator<<(std::ostream& out, const RouteSegment& r) {
@@ -36,10 +86,12 @@ public:
         return routeId < other.routeId || (routeId == other.routeId && stopIndex < other.stopIndex);
     }
 
-public:
+    // made it private in order to enforce using the getRouteId() / getStopIndex() method
+private:
     RouteId routeId;
     StopIndex stopIndex;
 
 };
-
+#endif
 }
+

--- a/DataStructures/TripBased/Data.h
+++ b/DataStructures/TripBased/Data.h
@@ -163,20 +163,20 @@ public:
     }
 
     inline TripId getEarliestTripLinear(const RAPTOR::RouteSegment& route, const int time) const noexcept {
-        if (route.stopIndex + 1 == raptorData.numberOfStopsInRoute(route.routeId)) return noTripId;
-        if (raptorData.lastTripOfRoute(route.routeId)[route.stopIndex].departureTime < time) return noTripId;
-        for (const TripId trip : tripsOfRoute(route.routeId)) {
-            if (getStopEvent(trip, route.stopIndex).departureTime >= time) return trip;
+        if (route.getStopIndex() + 1 == raptorData.numberOfStopsInRoute(route.getRouteId())) return noTripId;
+        if (raptorData.lastTripOfRoute(route.getRouteId())[route.getStopIndex()].departureTime < time) return noTripId;
+        for (const TripId trip : tripsOfRoute(route.getRouteId())) {
+            if (getStopEvent(trip, route.getStopIndex()).departureTime >= time) return trip;
         }
         return noTripId;
     }
 
     inline TripId getEarliestTripBinary(const RAPTOR::RouteSegment& route, const int time) const noexcept {
-        if (route.stopIndex + 1 == raptorData.numberOfStopsInRoute(route.routeId)) return noTripId;
-        const TripId trip = std::lower_bound(firstTripOfRoute[route.routeId], firstTripOfRoute[route.routeId + 1], time, [&](const TripId trip, const int time) {
-            return getStopEvent(trip, route.stopIndex).departureTime < time;
+        if (route.getStopIndex() + 1 == raptorData.numberOfStopsInRoute(route.getRouteId())) return noTripId;
+        const TripId trip = std::lower_bound(firstTripOfRoute[route.getRouteId()], firstTripOfRoute[route.getRouteId() + 1], time, [&](const TripId trip, const int time) {
+            return getStopEvent(trip, route.getStopIndex()).departureTime < time;
         });
-        if (trip < firstTripOfRoute[route.routeId + 1]) return trip;
+        if (trip < firstTripOfRoute[route.getRouteId() + 1]) return trip;
         return noTripId;
     }
 

--- a/Helpers/IO/ParserCSV.h
+++ b/Helpers/IO/ParserCSV.h
@@ -39,7 +39,12 @@ struct WithFileName {
     WithFileName() {std::memset(fileName, 0, MAX_FILE_NAME_LENGTH + 1);}
 
     void setFileName(const char* fileName) {
+// https://stackoverflow.com/a/50198710
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
         std::strncpy(this->fileName, fileName, MAX_FILE_NAME_LENGTH);
+#pragma GCC diagnostic pop
+ 
         this->fileName[MAX_FILE_NAME_LENGTH] = '\0';
     }
 

--- a/Helpers/Types.h
+++ b/Helpers/Types.h
@@ -19,7 +19,11 @@ using StopId = DependentTaggedInteger<2, Vertex>;
 constexpr StopId noStop(StopId::InvalidValue);
 
 using RouteId = TaggedInteger<3, u_int32_t, -u_int32_t(1)>;
+#ifdef USE_SMALLER_ROUTE_SEG
+constexpr RouteId noRouteId((1<<24)-1);
+#else
 constexpr RouteId noRouteId(RouteId::InvalidValue);
+#endif
 
 using TripId = TaggedInteger<4, u_int32_t, -u_int32_t(1)>;
 constexpr TripId noTripId(TripId::InvalidValue);

--- a/Runnables/Makefile
+++ b/Runnables/Makefile
@@ -1,6 +1,6 @@
 CC=g++ -fopenmp
 FLAGS=-std=c++17 -pipe
-OPTIMIZATION=-march=native -O3
+OPTIMIZATION=-march=native -O3 -DENABLE_PREFETCH -DUSE_SMALLER_ROUTE_SEG
 DEBUG=-rdynamic -Werror -Wpedantic -pedantic-errors -Wall -Wextra -Wparentheses -Wfatal-errors -D_GLIBCXX_DEBUG -g -fno-omit-frame-pointer
 RELEASE=-ffast-math -ftree-vectorize -Wfatal-errors -DNDEBUG
 

--- a/Runnables/Makefile
+++ b/Runnables/Makefile
@@ -1,6 +1,6 @@
 CC=g++ -fopenmp
 FLAGS=-std=c++17 -pipe
-OPTIMIZATION=-march=native -O3 -DENABLE_PREFETCH -DUSE_SMALLER_ROUTE_SEG
+OPTIMIZATION=-march=native -O3 -DENABLE_PREFETCH #-DUSE_SMALLER_ROUTE_SEG
 DEBUG=-rdynamic -Werror -Wpedantic -pedantic-errors -Wall -Wextra -Wparentheses -Wfatal-errors -D_GLIBCXX_DEBUG -g -fno-omit-frame-pointer
 RELEASE=-ffast-math -ftree-vectorize -Wfatal-errors -DNDEBUG
 

--- a/Runnables/downloadExample.sh
+++ b/Runnables/downloadExample.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Define the target directory and URL
+TARGET_DIR="../Datasets/Karlsruhe/GTFS"
+ZIP_URL="https://projekte.kvv-efa.de/GTFS/google_transit.zip"
+ZIP_FILE="$TARGET_DIR/google_transit.zip"
+
+# Create the target directory if it doesn't exist
+mkdir -p $TARGET_DIR
+
+# Download the zip file
+wget -O $ZIP_FILE $ZIP_URL
+
+# Extract the zip file into the target directory
+unzip -o $ZIP_FILE -d $TARGET_DIR
+
+# Clean up the zip file
+rm $ZIP_FILE
+
+echo "Download and extraction complete."
+

--- a/Runnables/exampleNetwork.script
+++ b/Runnables/exampleNetwork.script
@@ -1,0 +1,9 @@
+parseGTFS ../Datasets/Karlsruhe/GTFS/ ../Datasets/Karlsruhe/GTFS/GTFS.binary
+gtfsToIntermediate ../Datasets/Karlsruhe/GTFS/GTFS.binary 20240101 20240102 false false ../Datasets/Karlsruhe/intermediate.binary
+reduceToMaximumConnectedComponent ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/intermediate.binary
+reduceGraph ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/intermediate.binary
+makeOneHopTransfers ../Datasets/Karlsruhe/intermediate.binary 86400 ../Datasets/Karlsruhe/intermediate.binary true
+reduceToMaximumConnectedComponent ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/intermediate.binary
+reduceGraph ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/intermediate.binary
+intermediateToRAPTOR ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/raptor.binary
+intermediateToCSA ../Datasets/Karlsruhe/intermediate.binary ../Datasets/Karlsruhe/csa.binary


### PR DESCRIPTION
I added the possibility to serialize a graph (as is). You can still call "writeBinary", and every attribute is saved independently. But now, you can call `IO::serialize(fileName, graph, ...)` or even serialize a `vector<GRAPH>`, which is dumped in the same binary file as the rest.

I also changed the order in the initializer list in the DFS template and added a GraphML Exporter that exports the attributes.