### PR TITLE
Fixed bug in SparseRange where iterator can skip past end() on increment.

### DIFF
--- a/Helpers/Ranges/SparseRange.h
+++ b/Helpers/Ranges/SparseRange.h
@@ -15,16 +15,17 @@ public:
 public:
     class Iterator {
     public:
-        Iterator(const std::vector<bool>* const flag, const Element i) : flag(flag), i(i) {}
+        Iterator(const std::vector<bool>* const flag, const Element i, const Element endIndex) : flag(flag), i(i), endIndex(endIndex) {}
         inline bool operator!=(const Iterator& other) const noexcept {return i != other.i;}
         inline Element operator*() const noexcept {return i;}
-        inline Iterator& operator++() noexcept {do {++i;} while (i < flag->size() && !(*flag)[i]); return *this;}
+        inline Iterator& operator++() noexcept {do {++i;} while (i < endIndex && !(*flag)[i]); return *this;}
         inline Iterator& operator+=(const size_t n) noexcept {for (size_t j = 0; j < n; j++) ++(*this); return *this;}
         inline Iterator operator+(const size_t n) const noexcept {return Iterator(*this) += n;}
         inline Element operator[](const size_t n) const noexcept {return *(*this + n);}
     private:
         const std::vector<bool>* flag;
         Element i;
+        Element endIndex;
     };
 
     SparseRange() :
@@ -52,11 +53,11 @@ public:
     SparseRange(const std::vector<bool>&&) = delete;
 
     inline Iterator begin() const noexcept {
-        return Iterator(flag, beginIndex);
+        return Iterator(flag, beginIndex, endIndex);
     }
 
     inline Iterator end() const noexcept {
-        return Iterator(flag, endIndex);
+        return Iterator(flag, endIndex, endIndex);
     }
 
     inline bool empty() const noexcept {


### PR DESCRIPTION
The increment operator on the SparseRange::Iterator skips all indices i for which i < flag.size() && !flag[i]. This may include endIndex which is set to i+1 for the greatest i such that flag[i] holds upon construction of the SparseRange. Since endIndex determines the return value of SparseRange::end(), a common iterator-based or range-based loop may never reach end() exactly. Making sure that an iterator may never be incremented past endIndex fixes the issue.
